### PR TITLE
Add username, contact, and subscription fields to user

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -1,0 +1,98 @@
+using Imagino.Api.DTOs;
+using Imagino.Api.Models;
+using Imagino.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Imagino.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class UsersController : ControllerBase
+    {
+        private readonly IUserService _service;
+
+        public UsersController(IUserService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<UserDto>>> Get()
+        {
+            var users = await _service.GetAllAsync();
+            return Ok(users.Select(ToDto));
+        }
+
+        [AllowAnonymous]
+        [HttpGet("exists/{username}")]
+        public async Task<ActionResult<bool>> UsernameExists(string username)
+        {
+            var user = await _service.GetByUsernameAsync(username);
+            return Ok(user != null);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<UserDto>> GetById(string id)
+        {
+            var user = await _service.GetByIdAsync(id);
+            if (user == null) return NotFound();
+            return Ok(ToDto(user));
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<UserDto>> Create([FromBody] CreateUserDto dto)
+        {
+            var user = await _service.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = user.Id }, ToDto(user));
+        }
+
+        [HttpPut("{id}")]
+        public async Task<ActionResult<UserDto>> Update(string id, [FromBody] UpdateUserDto dto)
+        {
+            var user = await _service.UpdateAsync(id, dto);
+            if (user == null) return NotFound();
+            return Ok(ToDto(user));
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(string id)
+        {
+            await _service.DeleteAsync(id);
+            return NoContent();
+        }
+
+        [HttpPost("{id}/profile-image")]
+        [Consumes("multipart/form-data")]
+        public async Task<ActionResult> UploadProfileImage(string id, [FromForm] UploadProfileImageDto form)
+        {
+            var file = form.File;
+            if (file == null || file.Length == 0)
+                return BadRequest(new { message = "File not provided" });
+
+            var imageUrl = await _service.UpdateProfileImageAsync(id, file);
+            if (imageUrl == null) return NotFound();
+
+            return Ok(new { imageUrl });
+        }
+
+        private static UserDto ToDto(User user) =>
+            new(
+                user.Id!,
+                user.Email,
+                user.Username,
+                user.PhoneNumber,
+                user.Subscription,
+                user.Credits,
+                user.GoogleId,
+                user.ProfileImageUrl,
+                user.CreatedAt,
+                user.UpdatedAt);
+    }
+}
+

--- a/DTOs/CreateUserDto.cs
+++ b/DTOs/CreateUserDto.cs
@@ -1,0 +1,16 @@
+using System;
+using Imagino.Api.Models;
+
+namespace Imagino.Api.DTOs
+{
+    public class CreateUserDto
+    {
+        public string Email { get; set; } = default!;
+        public string Username { get; set; } = default!;
+        public string? PhoneNumber { get; set; }
+        public SubscriptionPlan Subscription { get; set; } = SubscriptionPlan.Free;
+        public int Credits { get; set; } = 0;
+        public string Password { get; set; } = default!;
+    }
+}
+

--- a/DTOs/UpdateUserDto.cs
+++ b/DTOs/UpdateUserDto.cs
@@ -1,0 +1,15 @@
+using Imagino.Api.Models;
+
+namespace Imagino.Api.DTOs
+{
+    public class UpdateUserDto
+    {
+        public string? Email { get; set; }
+        public string? Username { get; set; }
+        public string? PhoneNumber { get; set; }
+        public SubscriptionPlan? Subscription { get; set; }
+        public int? Credits { get; set; }
+        public string? Password { get; set; }
+        public string? ProfileImageUrl { get; set; }
+    }
+}

--- a/DTOs/UploadProfileImageDto.cs
+++ b/DTOs/UploadProfileImageDto.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Imagino.Api.DTOs
+{
+    public class UploadProfileImageDto
+    {
+        public IFormFile File { get; set; } = default!;
+    }
+}

--- a/DTOs/UserDto.cs
+++ b/DTOs/UserDto.cs
@@ -1,0 +1,18 @@
+using System;
+using Imagino.Api.Models;
+
+namespace Imagino.Api.DTOs
+{
+    public record UserDto(
+        string Id,
+        string? Email,
+        string? Username,
+        string? PhoneNumber,
+        SubscriptionPlan Subscription,
+        int Credits,
+        string? GoogleId,
+        string? ProfileImageUrl,
+        DateTime CreatedAt,
+        DateTime UpdatedAt);
+}
+

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ namespace Imagino.Api.DependencyInjection
             services.AddTransient<IReplicateJobsService, ReplicateJobsService>();
             services.AddTransient<IWebhookImageService, WebhookImageService>();
             services.AddTransient<IUserRepository, UserRepository>();
+            services.AddTransient<IUserService, UserService>();
             services.AddTransient<IJwtService, JwtService>();
 
 

--- a/Models/SubscriptionPlan.cs
+++ b/Models/SubscriptionPlan.cs
@@ -1,0 +1,9 @@
+namespace Imagino.Api.Models
+{
+    public enum SubscriptionPlan
+    {
+        Free,
+        Premium,
+        Ultra
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -12,8 +12,13 @@ namespace Imagino.Api.Models
         public string? Id { get; set; }
 
         public string? Email { get; set; }
+        public string? Username { get; set; }
+        public string? PhoneNumber { get; set; }
         public string? PasswordHash { get; set; }
         public string? GoogleId { get; set; }
+        public string? ProfileImageUrl { get; set; }
+        public SubscriptionPlan Subscription { get; set; } = SubscriptionPlan.Free;
+        public int Credits { get; set; } = 0;
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
     }

--- a/Repository/IUserRepository.cs
+++ b/Repository/IUserRepository.cs
@@ -6,6 +6,11 @@ namespace Imagino.Api.Repository
     {
         Task<User> GetByEmailAsync(string email);
         Task<User> GetByGoogleIdAsync(string googleId);
+        Task<User?> GetByUsernameAsync(string username);
+        Task<User?> GetByIdAsync(string id);
+        Task<IEnumerable<User>> GetAllAsync();
         Task CreateAsync(User user);
+        Task UpdateAsync(User user);
+        Task DeleteAsync(string id);
     }
 }

--- a/Repository/UserRepository.cs
+++ b/Repository/UserRepository.cs
@@ -3,6 +3,7 @@ using Imagino.Api.Repository;
 using Imagino.Api.Settings;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Imagino.Api.Repository
@@ -16,6 +17,11 @@ namespace Imagino.Api.Repository
             var client = new MongoClient(settings.Value.MongoConnection);
             var database = client.GetDatabase(settings.Value.MongoDatabase);
             _collection = database.GetCollection<User>("Users");
+
+            var indexKeys = Builders<User>.IndexKeys.Ascending(u => u.Username);
+            var indexOptions = new CreateIndexOptions { Unique = true, Sparse = true };
+            var indexModel = new CreateIndexModel<User>(indexKeys, indexOptions);
+            _collection.Indexes.CreateOne(indexModel);
         }
 
         public async Task<User> GetByEmailAsync(string email) =>
@@ -24,7 +30,22 @@ namespace Imagino.Api.Repository
         public async Task<User> GetByGoogleIdAsync(string googleId) =>
             await _collection.Find(u => u.GoogleId == googleId).FirstOrDefaultAsync();
 
+        public async Task<User?> GetByUsernameAsync(string username) =>
+            await _collection.Find(u => u.Username != null && u.Username.ToLower() == username.ToLower()).FirstOrDefaultAsync();
+
+        public async Task<User?> GetByIdAsync(string id) =>
+            await _collection.Find(u => u.Id == id).FirstOrDefaultAsync();
+
+        public async Task<IEnumerable<User>> GetAllAsync() =>
+            await _collection.Find(_ => true).ToListAsync();
+
         public async Task CreateAsync(User user) =>
             await _collection.InsertOneAsync(user);
+
+        public async Task UpdateAsync(User user) =>
+            await _collection.ReplaceOneAsync(u => u.Id == user.Id, user);
+
+        public async Task DeleteAsync(string id) =>
+            await _collection.DeleteOneAsync(u => u.Id == id);
     }
 }

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -1,0 +1,20 @@
+using Imagino.Api.DTOs;
+using Imagino.Api.Models;
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Imagino.Api.Services
+{
+    public interface IUserService
+    {
+        Task<IEnumerable<User>> GetAllAsync();
+        Task<User?> GetByIdAsync(string id);
+        Task<User?> GetByUsernameAsync(string username);
+        Task<User> CreateAsync(CreateUserDto dto);
+        Task<User?> UpdateAsync(string id, UpdateUserDto dto);
+        Task DeleteAsync(string id);
+        Task<string?> UpdateProfileImageAsync(string id, IFormFile file);
+    }
+}
+

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -1,0 +1,116 @@
+using Imagino.Api.DTOs;
+using Imagino.Api.Models;
+using Imagino.Api.Repository;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Imagino.Api.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly IUserRepository _repository;
+
+        public UserService(IUserRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<IEnumerable<User>> GetAllAsync() =>
+            await _repository.GetAllAsync();
+
+        public async Task<User?> GetByIdAsync(string id) =>
+            await _repository.GetByIdAsync(id);
+
+        public async Task<User?> GetByUsernameAsync(string username) =>
+            await _repository.GetByUsernameAsync(username);
+
+        public async Task<User> CreateAsync(CreateUserDto dto)
+        {
+            if (!string.IsNullOrEmpty(dto.Username))
+            {
+                var existing = await _repository.GetByUsernameAsync(dto.Username);
+                if (existing != null) throw new ArgumentException("Username already in use");
+            }
+
+            var user = new User
+            {
+                Email = dto.Email,
+                Username = dto.Username,
+                PhoneNumber = dto.PhoneNumber,
+                Subscription = dto.Subscription,
+                Credits = dto.Credits,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password)
+            };
+
+            await _repository.CreateAsync(user);
+            return user;
+        }
+
+        public async Task<User?> UpdateAsync(string id, UpdateUserDto dto)
+        {
+            var user = await _repository.GetByIdAsync(id);
+            if (user == null) return null;
+
+            if (!string.IsNullOrEmpty(dto.Email))
+                user.Email = dto.Email;
+
+            if (!string.IsNullOrEmpty(dto.Username) && dto.Username != user.Username)
+            {
+                var existing = await _repository.GetByUsernameAsync(dto.Username);
+                if (existing != null && existing.Id != user.Id)
+                    throw new ArgumentException("Username already in use");
+                user.Username = dto.Username;
+            }
+
+            if (!string.IsNullOrEmpty(dto.PhoneNumber))
+                user.PhoneNumber = dto.PhoneNumber;
+
+            if (dto.Subscription.HasValue)
+                user.Subscription = dto.Subscription.Value;
+
+            if (dto.Credits.HasValue)
+                user.Credits = dto.Credits.Value;
+
+            if (!string.IsNullOrEmpty(dto.Password))
+                user.PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password);
+
+            if (!string.IsNullOrEmpty(dto.ProfileImageUrl))
+                user.ProfileImageUrl = dto.ProfileImageUrl;
+
+            user.UpdatedAt = DateTime.UtcNow;
+
+            await _repository.UpdateAsync(user);
+            return user;
+        }
+
+        public async Task DeleteAsync(string id) =>
+            await _repository.DeleteAsync(id);
+
+        public async Task<string?> UpdateProfileImageAsync(string id, IFormFile file)
+        {
+            var user = await _repository.GetByIdAsync(id);
+            if (user == null) return null;
+
+            var uploads = Path.Combine("wwwroot", "profile-images");
+            Directory.CreateDirectory(uploads);
+
+            var fileName = $"{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+            var filePath = Path.Combine(uploads, fileName);
+
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            user.ProfileImageUrl = $"/profile-images/{fileName}";
+            user.UpdatedAt = DateTime.UtcNow;
+            await _repository.UpdateAsync(user);
+
+            return user.ProfileImageUrl;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend User model with username, phone, subscription plan, and credit balance
- expose username availability check endpoint and update DTOs/service logic
- enforce unique usernames with a Mongo index

## Testing
- `dotnet build Imagino.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689ce0960c80832f933a0e0989b396f0