### PR TITLE
feat(user): add profile fields and subscription

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -22,22 +22,30 @@ namespace Imagino.Api.Controllers
             _config = config;
         }
 
-        public record RegisterRequest(string Email, string Password);
+        public record RegisterRequest(string Email, string Password, string Username, string? PhoneNumber, SubscriptionType Subscription, int Credits);
         public record LoginRequest(string Email, string Password);
 
         [HttpPost("register")]
         public async Task<IActionResult> Register([FromBody] RegisterRequest request)
         {
-            var existing = await _users.GetByEmailAsync(request.Email);
-            if (existing != null)
+            var existingEmail = await _users.GetByEmailAsync(request.Email);
+            if (existingEmail != null)
                 return BadRequest(new { message = "Email already in use" });
+
+            var existingUsername = await _users.GetByUsernameAsync(request.Username);
+            if (existingUsername != null)
+                return BadRequest(new { message = "Username already in use" });
 
             var hash = BCrypt.Net.BCrypt.HashPassword(request.Password);
 
             var user = new User
             {
                 Email = request.Email,
-                PasswordHash = hash
+                PasswordHash = hash,
+                Username = request.Username,
+                PhoneNumber = request.PhoneNumber,
+                Subscription = request.Subscription,
+                Credits = request.Credits
             };
 
             await _users.CreateAsync(user);

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -4,6 +4,7 @@ using Imagino.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -40,8 +41,15 @@ namespace Imagino.Api.Controllers
         [HttpPost]
         public async Task<ActionResult<UserDto>> Create([FromBody] CreateUserDto dto)
         {
-            var user = await _service.CreateAsync(dto);
-            return CreatedAtAction(nameof(GetById), new { id = user.Id }, ToDto(user));
+            try
+            {
+                var user = await _service.CreateAsync(dto);
+                return CreatedAtAction(nameof(GetById), new { id = user.Id }, ToDto(user));
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
         }
 
         [HttpPut("{id}")]
@@ -74,7 +82,7 @@ namespace Imagino.Api.Controllers
         }
 
         private static UserDto ToDto(User user) =>
-            new(user.Id!, user.Email, user.GoogleId, user.ProfileImageUrl, user.CreatedAt, user.UpdatedAt);
+            new(user.Id!, user.Email, user.GoogleId, user.ProfileImageUrl, user.Username, user.PhoneNumber, user.Subscription, user.Credits, user.CreatedAt, user.UpdatedAt);
     }
 }
 

--- a/DTOs/CreateUserDto.cs
+++ b/DTOs/CreateUserDto.cs
@@ -1,4 +1,5 @@
 using System;
+using Imagino.Api.Models;
 
 namespace Imagino.Api.DTOs
 {
@@ -6,6 +7,10 @@ namespace Imagino.Api.DTOs
     {
         public string Email { get; set; } = default!;
         public string Password { get; set; } = default!;
+        public string Username { get; set; } = default!;
+        public string? PhoneNumber { get; set; }
+        public SubscriptionType Subscription { get; set; } = SubscriptionType.Free;
+        public int Credits { get; set; } = 0;
     }
 }
 

--- a/DTOs/UpdateUserDto.cs
+++ b/DTOs/UpdateUserDto.cs
@@ -1,3 +1,5 @@
+using Imagino.Api.Models;
+
 namespace Imagino.Api.DTOs
 {
     public class UpdateUserDto
@@ -5,6 +7,10 @@ namespace Imagino.Api.DTOs
         public string? Email { get; set; }
         public string? Password { get; set; }
         public string? ProfileImageUrl { get; set; }
+        public string? Username { get; set; }
+        public string? PhoneNumber { get; set; }
+        public SubscriptionType? Subscription { get; set; }
+        public int? Credits { get; set; }
     }
 }
 

--- a/DTOs/UserDto.cs
+++ b/DTOs/UserDto.cs
@@ -1,4 +1,5 @@
 using System;
+using Imagino.Api.Models;
 
 namespace Imagino.Api.DTOs
 {
@@ -7,6 +8,10 @@ namespace Imagino.Api.DTOs
         string? Email,
         string? GoogleId,
         string? ProfileImageUrl,
+        string Username,
+        string? PhoneNumber,
+        SubscriptionType Subscription,
+        int Credits,
         DateTime CreatedAt,
         DateTime UpdatedAt);
 }

--- a/Models/SubscriptionType.cs
+++ b/Models/SubscriptionType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Imagino.Api.Models
+{
+    public enum SubscriptionType
+    {
+        Free,
+        Premium,
+        Ultra
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -15,6 +15,12 @@ namespace Imagino.Api.Models
         public string? PasswordHash { get; set; }
         public string? GoogleId { get; set; }
         public string? ProfileImageUrl { get; set; }
+        public string Username { get; set; } = default!;
+        public string? PhoneNumber { get; set; }
+
+        [BsonRepresentation(BsonType.String)]
+        public SubscriptionType Subscription { get; set; } = SubscriptionType.Free;
+        public int Credits { get; set; } = 0;
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
     }

--- a/Repository/IUserRepository.cs
+++ b/Repository/IUserRepository.cs
@@ -6,6 +6,7 @@ namespace Imagino.Api.Repository
     {
         Task<User> GetByEmailAsync(string email);
         Task<User> GetByGoogleIdAsync(string googleId);
+        Task<User?> GetByUsernameAsync(string username);
         Task<User?> GetByIdAsync(string id);
         Task<IEnumerable<User>> GetAllAsync();
         Task CreateAsync(User user);

--- a/Repository/UserRepository.cs
+++ b/Repository/UserRepository.cs
@@ -25,6 +25,9 @@ namespace Imagino.Api.Repository
         public async Task<User> GetByGoogleIdAsync(string googleId) =>
             await _collection.Find(u => u.GoogleId == googleId).FirstOrDefaultAsync();
 
+        public async Task<User?> GetByUsernameAsync(string username) =>
+            await _collection.Find(u => u.Username.ToLower() == username.ToLower()).FirstOrDefaultAsync();
+
         public async Task<User?> GetByIdAsync(string id) =>
             await _collection.Find(u => u.Id == id).FirstOrDefaultAsync();
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -26,10 +26,18 @@ namespace Imagino.Api.Services
 
         public async Task<User> CreateAsync(CreateUserDto dto)
         {
+            var existing = await _repository.GetByUsernameAsync(dto.Username);
+            if (existing != null)
+                throw new ArgumentException("Username already in use");
+
             var user = new User
             {
                 Email = dto.Email,
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password)
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password),
+                Username = dto.Username,
+                PhoneNumber = dto.PhoneNumber,
+                Subscription = dto.Subscription,
+                Credits = dto.Credits
             };
 
             await _repository.CreateAsync(user);
@@ -49,6 +57,23 @@ namespace Imagino.Api.Services
 
             if (!string.IsNullOrEmpty(dto.ProfileImageUrl))
                 user.ProfileImageUrl = dto.ProfileImageUrl;
+
+            if (!string.IsNullOrEmpty(dto.Username))
+            {
+                var existing = await _repository.GetByUsernameAsync(dto.Username);
+                if (existing != null && existing.Id != user.Id)
+                    throw new ArgumentException("Username already in use");
+                user.Username = dto.Username;
+            }
+
+            if (!string.IsNullOrEmpty(dto.PhoneNumber))
+                user.PhoneNumber = dto.PhoneNumber;
+
+            if (dto.Subscription.HasValue)
+                user.Subscription = dto.Subscription.Value;
+
+            if (dto.Credits.HasValue)
+                user.Credits = dto.Credits.Value;
 
             user.UpdatedAt = DateTime.UtcNow;
 


### PR DESCRIPTION
## Summary
- add username, phone number, subscription tier and credits to user model and DTOs
- enforce unique usernames and expose repository lookup
- extend auth registration to capture new user profile data

## Testing
- `dotnet test` *(fails: project file /workspace/Imagino.Api.Test/Imagino.Api.Tests.csproj not found)*
- `dotnet build Imagino.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689d40bc5844832fb968d1e99e5eab93