### PR TITLE
feat: generate usernames automatically

### DIFF
--- a/DTOs/CreateUserDto.cs
+++ b/DTOs/CreateUserDto.cs
@@ -7,7 +7,7 @@ namespace Imagino.Api.DTOs
     {
         public string Email { get; set; } = default!;
         public string Password { get; set; } = default!;
-        public string Username { get; set; } = default!;
+        public string? Username { get; set; }
         public string? PhoneNumber { get; set; }
         public SubscriptionType Subscription { get; set; } = SubscriptionType.Free;
         public int Credits { get; set; } = 0;

--- a/Imagino.Api.Tests/Imagino.Api.Tests.csproj
+++ b/Imagino.Api.Tests/Imagino.Api.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Imagino.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/Imagino.Api.Tests/UserServiceTests.cs
+++ b/Imagino.Api.Tests/UserServiceTests.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using Imagino.Api.DTOs;
+using Imagino.Api.Models;
+using Imagino.Api.Repository;
+using Imagino.Api.Services;
+using Moq;
+using Xunit;
+
+#nullable enable
+
+namespace Imagino.Api.Tests
+{
+    public class UserServiceTests
+    {
+        [Fact]
+        public async Task CreateAsync_GeneratesUniqueUsername_WhenUsernameMissing()
+        {
+            var repo = new Mock<IUserRepository>();
+            repo.Setup(r => r.GetByUsernameAsync(It.IsAny<string>()))
+                .Returns<string>(u => Task.FromResult<User?>(u == "john" ? new User() : null));
+            User? created = null;
+            repo.Setup(r => r.CreateAsync(It.IsAny<User>()))
+                .Callback<User>(u => created = u)
+                .Returns(Task.CompletedTask);
+
+            var service = new UserService(repo.Object);
+            var dto = new CreateUserDto { Email = "john@example.com", Password = "pass" };
+            var user = await service.CreateAsync(dto);
+
+            Assert.NotNull(created);
+            Assert.StartsWith("john", created!.Username);
+            Assert.NotEqual("john", created.Username);
+        }
+
+        [Fact]
+        public async Task GenerateUsernameFromEmailAsync_GeneratesUnique_WhenDuplicateExists()
+        {
+            var repo = new Mock<IUserRepository>();
+            repo.Setup(r => r.GetByUsernameAsync(It.IsAny<string>()))
+                .Returns<string>(u => Task.FromResult<User?>(u == "jane" ? new User() : null));
+
+            var service = new UserService(repo.Object);
+            var username = await service.GenerateUsernameFromEmailAsync("jane@example.com");
+
+            Assert.StartsWith("jane", username);
+            Assert.NotEqual("jane", username);
+        }
+    }
+}

--- a/Imagino.Api.csproj
+++ b/Imagino.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,7 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Utils\" />
+    <Folder Include="Utils\\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Imagino.Api.Tests/**/*" />
+    <None Remove="Imagino.Api.Tests/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Imagino.Api.sln
+++ b/Imagino.Api.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.13.35825.156
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Imagino.Api", "Imagino.Api.csproj", "{DC4BAD70-38E6-453F-AF70-6DEC0AC6C725}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Imagino.Api.Tests", "..\Imagino.Api.Test\Imagino.Api.Tests.csproj", "{436863AA-BE7F-4649-B347-21E421E65440}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Imagino.Api.Tests", "Imagino.Api.Tests\Imagino.Api.Tests.csproj", "{436863AA-BE7F-4649-B347-21E421E65440}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -14,6 +14,7 @@ namespace Imagino.Api.Services
         Task<User?> UpdateAsync(string id, UpdateUserDto dto);
         Task DeleteAsync(string id);
         Task<string?> UpdateProfileImageAsync(string id, IFormFile file);
+        Task<string> GenerateUsernameFromEmailAsync(string email);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow optional username on registration
- generate unique slugs from email when username absent
- propagate provisional usernames across auth endpoints and Google sign-ups
- add unit tests for username generation

## Testing
- `dotnet test Imagino.Api.sln`

------
https://chatgpt.com/codex/tasks/task_e_689def23bb90832fbcd353777e2612da