### PR TITLE
Add job details endpoint for image modal

### DIFF
--- a/Controllers/JobsController.cs
+++ b/Controllers/JobsController.cs
@@ -1,6 +1,8 @@
 ﻿using Imagino.Api.DTOs;
 using Imagino.Api.Models;
 using Imagino.Api.Services.ImageGeneration;
+using Imagino.Api.Repository;
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.JsonWebTokens;
@@ -15,9 +17,13 @@ namespace Imagino.Api.Controllers;
 [Route("api/jobs")]
 [Authorize]
 
-public class JobsController(IJobsService imageService) : ControllerBase
+public class JobsController(IJobsService imageService,
+                            IImageJobRepository jobRepository,
+                            IUserRepository userRepository) : ControllerBase
 {
     private readonly IJobsService _imageService = imageService;
+    private readonly IImageJobRepository _jobRepository = jobRepository;
+    private readonly IUserRepository _userRepository = userRepository;
 
     /// <summary>
     /// Creates a new image generation job.
@@ -58,5 +64,28 @@ public class JobsController(IJobsService imageService) : ControllerBase
             return NotFound(result);
 
         return Ok(result);
+    }
+
+    [HttpGet("details/{jobId}")]
+    public async Task<IActionResult> GetJobDetails(string jobId)
+    {
+        var job = await _jobRepository.GetByJobIdAsync(jobId);
+        if (job == null)
+            return NotFound();
+
+        var user = string.IsNullOrEmpty(job.UserId)
+            ? null
+            : await _userRepository.GetByIdAsync(job.UserId);
+
+        var response = new
+        {
+            ImageUrl = job.ImageUrls.FirstOrDefault(),
+            job.Prompt,
+            UserName = user?.Username,
+            job.CreatedAt,
+            Resolution = job.AspectRatio
+        };
+
+        return Ok(response);
     }
 }

--- a/Models/ImageJob.cs
+++ b/Models/ImageJob.cs
@@ -24,6 +24,9 @@ namespace Imagino.Api.Models
         [BsonElement("imageUrls")]
         public List<string> ImageUrls { get; set; } = new();
 
+        [BsonElement("aspectRatio")]
+        public string AspectRatio { get; set; } = string.Empty;
+
         [BsonElement("createdAt")]
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/Services/ImageGeneration/JobsService.cs
+++ b/Services/ImageGeneration/JobsService.cs
@@ -62,6 +62,7 @@ namespace Imagino.Api.Services.ImageGeneration
                     JobId = runpodRaw!.id,
                     Status = runpodRaw.status.ToLower(),
                     UserId = userId,
+                    AspectRatio = CalculateAspectRatio(request.Width, request.Height),
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow,
                     ImageUrls = new List<string>()
@@ -104,6 +105,13 @@ namespace Imagino.Api.Services.ImageGeneration
             };
 
             return result;
+        }
+
+        private static string CalculateAspectRatio(int width, int height)
+        {
+            static int Gcd(int a, int b) => b == 0 ? a : Gcd(b, a % b);
+            var gcd = Gcd(width, height);
+            return $"{width / gcd}:{height / gcd}";
         }
     }
 

--- a/Services/ImageGeneration/ReplicateJobsService.cs
+++ b/Services/ImageGeneration/ReplicateJobsService.cs
@@ -73,7 +73,8 @@ namespace Imagino.Api.Services.ImageGeneration
                     Status = replicateResponse.status.ToLower(),
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow,
-                    UserId = userId
+                    UserId = userId,
+                    AspectRatio = request.AspectRatio
                 };
 
                 await _jobRepository.InsertAsync(imageJob);


### PR DESCRIPTION
## Summary
- extend ImageJob with aspect ratio field
- populate aspect ratio when creating jobs
- add `/api/jobs/details/{jobId}` endpoint to expose image URL, prompt, user name, created date, and resolution

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689f40d7d39c832fa6a5248d3f109eb4