### PR TITLE
Add user credit management

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -98,10 +98,17 @@ namespace Imagino.Api.Controllers
             return Ok(new { credits });
         }
 
-        [HttpGet("{id}/credits")]
-        public async Task<ActionResult> GetCredits(string id)
+        [HttpGet("credits")]
+        public async Task<ActionResult> GetCredits()
         {
-            var credits = await _service.GetCreditsAsync(id);
+            var userId =
+               User.FindFirstValue(JwtRegisteredClaimNames.Sub) ??
+               User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized("User ID not found");
+
+            var credits = await _service.GetCreditsAsync(userId);
             if (credits is null) return NotFound();
             return Ok(new { credits });
         }

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -89,6 +89,23 @@ namespace Imagino.Api.Controllers
             return Ok(new { imageUrl });
         }
 
+        [HttpPost("{id}/credits")]
+        public async Task<IActionResult> AddCredits(string id, [FromBody] UpdateCreditsDto dto)
+        {
+            var success = await _service.IncrementCreditsAsync(id, dto.Amount);
+            if (!success) return NotFound();
+            var credits = await _service.GetCreditsAsync(id);
+            return Ok(new { credits });
+        }
+
+        [HttpGet("{id}/credits")]
+        public async Task<ActionResult> GetCredits(string id)
+        {
+            var credits = await _service.GetCreditsAsync(id);
+            if (credits is null) return NotFound();
+            return Ok(new { credits });
+        }
+
         private static UserDto ToDto(User user) =>
             new(user.Id!, user.Email, user.GoogleId, user.ProfileImageUrl, user.Username, user.PhoneNumber, user.Subscription, user.Credits, user.CreatedAt, user.UpdatedAt);
     }

--- a/DTOs/UpdateCreditsDto.cs
+++ b/DTOs/UpdateCreditsDto.cs
@@ -1,0 +1,7 @@
+namespace Imagino.Api.DTOs
+{
+    public class UpdateCreditsDto
+    {
+        public int Amount { get; set; }
+    }
+}

--- a/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/DependencyInjection/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ namespace Imagino.Api.DependencyInjection
             services.AddHttpClient<JobsService, JobsService>();
             services.AddTransient<IJobsService, JobsService>();
             services.AddTransient<IImageJobRepository, ImageJobRepository>();
+            services.AddHttpClient<ReplicateJobsService, ReplicateJobsService>();
             services.AddTransient<IReplicateJobsService, ReplicateJobsService>();
             services.AddTransient<IWebhookImageService, WebhookImageService>();
             services.AddTransient<IUserRepository, UserRepository>();

--- a/Imagino.Api.Tests/ReplicateJobsServiceTests.cs
+++ b/Imagino.Api.Tests/ReplicateJobsServiceTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Imagino.Api.DTOs;
+using Imagino.Api.Models;
+using Imagino.Api.Repository;
+using Imagino.Api.Services.ImageGeneration;
+using Imagino.Api.Settings;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Imagino.Api.Tests
+{
+    public class ReplicateJobsServiceTests
+    {
+        [Fact]
+        public async Task GenerateImageAsync_ReturnsError_WhenInsufficientCredits()
+        {
+            // Arrange
+            var httpClient = new HttpClient(new FakeHandler());
+            var replicateSettings = Options.Create(new ReplicateSettings { ApiKey = "k", ModelUrl = "http://localhost", WebhookUrl = "http://localhost" });
+            var imageSettings = Options.Create(new ImageGeneratorSettings { ImageCost = 5 });
+
+            var jobRepo = new Mock<IImageJobRepository>();
+            var userRepo = new Mock<IUserRepository>();
+            userRepo.Setup(r => r.GetByIdAsync("user1")).ReturnsAsync(new User { Id = "user1", Credits = 1 });
+
+            var service = new ReplicateJobsService(httpClient, replicateSettings, jobRepo.Object, userRepo.Object, imageSettings);
+            var request = new ImageGenerationReplicateRequest { Prompt = "test" };
+
+            // Act
+            var result = await service.GenerateImageAsync(request, "user1");
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Contains("Insufficient credits.", result.Errors);
+        }
+
+        private class FakeHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"id\":\"1\",\"status\":\"succeeded\"}")
+                };
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/Imagino.Api.Tests/UserServiceTests.cs
+++ b/Imagino.Api.Tests/UserServiceTests.cs
@@ -45,5 +45,30 @@ namespace Imagino.Api.Tests
             Assert.StartsWith("jane", username);
             Assert.NotEqual("jane", username);
         }
+
+        [Fact]
+        public async Task IncrementCreditsAsync_CallsRepository()
+        {
+            var repo = new Mock<IUserRepository>();
+            repo.Setup(r => r.IncrementCreditsAsync("1", 5)).ReturnsAsync(true);
+            var service = new UserService(repo.Object);
+
+            var result = await service.IncrementCreditsAsync("1", 5);
+
+            Assert.True(result);
+            repo.Verify(r => r.IncrementCreditsAsync("1", 5), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetCreditsAsync_ReturnsValue()
+        {
+            var repo = new Mock<IUserRepository>();
+            repo.Setup(r => r.GetCreditsAsync("1")).ReturnsAsync(10);
+            var service = new UserService(repo.Object);
+
+            var credits = await service.GetCreditsAsync("1");
+
+            Assert.Equal(10, credits);
+        }
     }
 }

--- a/Models/ImageJob.cs
+++ b/Models/ImageJob.cs
@@ -24,6 +24,9 @@ namespace Imagino.Api.Models
         [BsonElement("imageUrls")]
         public List<string> ImageUrls { get; set; } = new();
 
+        [BsonElement("tokenConsumed")]
+        public bool TokenConsumed { get; set; } = false;
+
         [BsonElement("aspectRatio")]
         public string AspectRatio { get; set; } = string.Empty;
 

--- a/Repository/IUserRepository.cs
+++ b/Repository/IUserRepository.cs
@@ -12,5 +12,8 @@ namespace Imagino.Api.Repository
         Task CreateAsync(User user);
         Task UpdateAsync(User user);
         Task DeleteAsync(string id);
+        Task<bool> DecrementCreditsAsync(string userId, int amount);
+        Task<bool> IncrementCreditsAsync(string userId, int amount);
+        Task<int?> GetCreditsAsync(string userId);
     }
 }

--- a/Repository/UserRepository.cs
+++ b/Repository/UserRepository.cs
@@ -42,5 +42,30 @@ namespace Imagino.Api.Repository
 
         public async Task DeleteAsync(string id) =>
             await _collection.DeleteOneAsync(u => u.Id == id);
+
+        public async Task<bool> DecrementCreditsAsync(string userId, int amount)
+        {
+            var filter = Builders<User>.Filter.And(
+                Builders<User>.Filter.Eq(u => u.Id, userId),
+                Builders<User>.Filter.Gte(u => u.Credits, amount));
+            var update = Builders<User>.Update.Inc(u => u.Credits, -amount);
+
+            var result = await _collection.UpdateOneAsync(filter, update);
+            return result.ModifiedCount == 1;
+        }
+
+        public async Task<bool> IncrementCreditsAsync(string userId, int amount)
+        {
+            var update = Builders<User>.Update.Inc(u => u.Credits, amount);
+            var result = await _collection.UpdateOneAsync(u => u.Id == userId, update);
+            return result.ModifiedCount == 1;
+        }
+
+        public async Task<int?> GetCreditsAsync(string userId)
+        {
+            var filter = Builders<User>.Filter.Eq(u => u.Id, userId);
+            var result = await _collection.Find(filter).Project(u => (int?)u.Credits).FirstOrDefaultAsync();
+            return result;
+        }
     }
 }

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -15,6 +15,8 @@ namespace Imagino.Api.Services
         Task DeleteAsync(string id);
         Task<string?> UpdateProfileImageAsync(string id, IFormFile file);
         Task<string> GenerateUsernameFromEmailAsync(string email);
+        Task<bool> IncrementCreditsAsync(string userId, int amount);
+        Task<int?> GetCreditsAsync(string userId);
     }
 }
 

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -135,6 +135,12 @@ namespace Imagino.Api.Services
 
             return user.ProfileImageUrl;
         }
+
+        public async Task<bool> IncrementCreditsAsync(string userId, int amount) =>
+            await _repository.IncrementCreditsAsync(userId, amount);
+
+        public async Task<int?> GetCreditsAsync(string userId) =>
+            await _repository.GetCreditsAsync(userId);
     }
 }
 

--- a/Settings/ImageGeneratorSettings.cs
+++ b/Settings/ImageGeneratorSettings.cs
@@ -8,5 +8,6 @@
         public string MongoDatabase { get; set; } = string.Empty;
         public string WebhookUrl { get; set; } = string.Empty;
         public string JobsCollection { get; set; } = "image_jobs";
+        public int ImageCost { get; set; } = 5;
     }
 }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -11,13 +11,13 @@
     "MongoConnection": "mongodb+srv://danielzanelato1:Zanelato2025%21@imagino-cluster.oref9np.mongodb.net/",
     "MongoDatabase": "imagino",
     "JobsCollection": "image_jobs",
-    "WebhookUrl": "https://d525341e9ca5.ngrok-free.app/api/webhooks/runpod",
+    "WebhookUrl": "https://c492f48178b6.ngrok-free.app/api/webhooks/runpod",
     "ImageCost": 5
   },
   "ReplicateSettings": {
     "ApiKey": "",
     "ModelUrl": "https://api.replicate.com/v1/models/black-forest-labs/flux-1.1-pro/predictions",
-    "WebhookUrl": "https://d525341e9ca5.ngrok-free.app/api/webhooks/replicate"
+    "WebhookUrl": "https://c492f48178b6.ngrok-free.app/api/webhooks/replicate"
   },
   "Jwt": {
     "Secret": "",

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -11,7 +11,8 @@
     "MongoConnection": "mongodb+srv://danielzanelato1:Zanelato2025%21@imagino-cluster.oref9np.mongodb.net/",
     "MongoDatabase": "imagino",
     "JobsCollection": "image_jobs",
-    "WebhookUrl": "https://d525341e9ca5.ngrok-free.app/api/webhooks/runpod"
+    "WebhookUrl": "https://d525341e9ca5.ngrok-free.app/api/webhooks/runpod",
+    "ImageCost": 5
   },
   "ReplicateSettings": {
     "ApiKey": "",

--- a/appsettings.json
+++ b/appsettings.json
@@ -11,7 +11,8 @@
     "RunPodApiKey": "rpa_H6FXAAKCO0WSPWHDVKBW0MYYQ33ND9H1JWP2TDISdawngr",
     "MongoConnection": "mongodb+srv://danielzanelato1:jqCPz5YZWyRgJzBH@imagino-cluster.mongodb.net/?retryWrites=true&w=majority",
     "MongoDatabase": "imagino",
-    "JobsCollection": "image_jobs"
+    "JobsCollection": "image_jobs",
+    "ImageCost": 5
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- add ImageCost setting to configure per-image credit use
- implement credit increment and retrieval in user repository/service
- expose endpoints for adding and fetching user credits and deduct correct cost
- check user balance before starting replicate jobs and register its HttpClient
- add unit test ensuring replicate jobs fail when credits are insufficient

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a08aa0653c832fb13be325ddd20323