### PR TITLE
feat: add endpoint for latest image jobs

### DIFF
--- a/Controllers/JobsController.cs
+++ b/Controllers/JobsController.cs
@@ -88,4 +88,29 @@ public class JobsController(IJobsService imageService,
 
         return Ok(response);
     }
+
+    [HttpGet("latest")]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetLatestJobs()
+    {
+        var jobs = await _jobRepository.GetLatestAsync(12);
+        var responseTasks = jobs.Select(async job =>
+        {
+            var user = string.IsNullOrEmpty(job.UserId)
+                ? null
+                : await _userRepository.GetByIdAsync(job.UserId);
+
+            return new
+            {
+                ImageUrl = job.ImageUrls.FirstOrDefault(),
+                job.Prompt,
+                Username = user?.Username,
+                job.CreatedAt,
+                AspectRatio = job.AspectRatio
+            };
+        });
+
+        var response = await Task.WhenAll(responseTasks);
+        return Ok(response);
+    }
 }

--- a/Controllers/JobsController.cs
+++ b/Controllers/JobsController.cs
@@ -102,6 +102,7 @@ public class JobsController(IJobsService imageService,
 
             return new
             {
+                Id = job.Id,
                 ImageUrl = job.ImageUrls.FirstOrDefault(),
                 job.Prompt,
                 Username = user?.Username,

--- a/Imagino.Api.Tests/JobsControllerTests.cs
+++ b/Imagino.Api.Tests/JobsControllerTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Imagino.Api.Controllers;
+using Imagino.Api.Models;
+using Imagino.Api.Repository;
+using Imagino.Api.Services.ImageGeneration;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Imagino.Api.Tests;
+
+public class JobsControllerTests
+{
+    [Fact]
+    public async Task GetLatestJobs_ReturnsIdFieldForEachJob()
+    {
+        // Arrange
+        var jobs = new List<ImageJob>
+        {
+            new()
+            {
+                Id = "1",
+                JobId = "job1",
+                ImageUrls = new List<string>{"url1"},
+                Prompt = "prompt1",
+                AspectRatio = "1:1",
+                CreatedAt = DateTime.UtcNow
+            },
+            new()
+            {
+                Id = "2",
+                JobId = "job2",
+                ImageUrls = new List<string>{"url2"},
+                Prompt = "prompt2",
+                AspectRatio = "1:1",
+                CreatedAt = DateTime.UtcNow
+            }
+        };
+
+        var jobRepo = new Mock<IImageJobRepository>();
+        jobRepo.Setup(r => r.GetLatestAsync(12)).ReturnsAsync(jobs);
+
+        var userRepo = new Mock<IUserRepository>();
+        var jobsService = new Mock<IJobsService>();
+
+        var controller = new JobsController(jobsService.Object, jobRepo.Object, userRepo.Object);
+
+        // Act
+        var result = await controller.GetLatestJobs();
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsAssignableFrom<IEnumerable<object>>(ok.Value);
+
+        foreach (var item in response)
+        {
+            var idProp = item.GetType().GetProperty("Id");
+            Assert.NotNull(idProp);
+            var value = idProp!.GetValue(item) as string;
+            Assert.False(string.IsNullOrEmpty(value));
+        }
+    }
+}
+

--- a/Repository/IImageJobRepository.cs
+++ b/Repository/IImageJobRepository.cs
@@ -8,5 +8,6 @@ namespace Imagino.Api.Repository
         Task<ImageJob> GetByJobIdAsync(string jobId);
         Task UpdateAsync(ImageJob job);
         Task<List<ImageJob>> GetByUserIdAsync(string userId);
+        Task<List<ImageJob>> GetLatestAsync(int limit);
     }
 }

--- a/Repository/ImageJobRepository.cs
+++ b/Repository/ImageJobRepository.cs
@@ -39,5 +39,13 @@ namespace Imagino.Api.Repository
                                     .ToListAsync();
         }
 
+        public async Task<List<ImageJob>> GetLatestAsync(int limit)
+        {
+            return await _collection.Find(_ => true)
+                                    .SortByDescending(job => job.CreatedAt)
+                                    .Limit(limit)
+                                    .ToListAsync();
+        }
+
     }
 }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -11,13 +11,13 @@
     "MongoConnection": "mongodb+srv://danielzanelato1:Zanelato2025%21@imagino-cluster.oref9np.mongodb.net/",
     "MongoDatabase": "imagino",
     "JobsCollection": "image_jobs",
-    "WebhookUrl": "https://c492f48178b6.ngrok-free.app/api/webhooks/runpod",
+    "WebhookUrl": "https://02fa06e3ba23.ngrok-free.app/api/webhooks/runpod",
     "ImageCost": 5
   },
   "ReplicateSettings": {
     "ApiKey": "",
     "ModelUrl": "https://api.replicate.com/v1/models/black-forest-labs/flux-1.1-pro/predictions",
-    "WebhookUrl": "https://c492f48178b6.ngrok-free.app/api/webhooks/replicate"
+    "WebhookUrl": "https://02fa06e3ba23.ngrok-free.app/api/webhooks/replicate"
   },
   "Jwt": {
     "Secret": "",


### PR DESCRIPTION
## Summary
- add repository method to fetch most recent image jobs
- expose `/api/jobs/latest` endpoint returning the last 12 jobs with creator info

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a13b9cd3f0832f9858b68c82ab67db