### PR TITLE
Add presigned download URL endpoint

### DIFF
--- a/Controllers/FilesController.cs
+++ b/Controllers/FilesController.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Imagino.Api.Services.Storage;
+
+namespace Imagino.Api.Controllers;
+
+[ApiController]
+[Route("api/files")]
+public class FilesController : ControllerBase
+{
+    private readonly IStorageService _storage;
+    public FilesController(IStorageService storage) => _storage = storage;
+
+    // GET /api/files/download-url?key=images/abc.png&prompt=...
+    [HttpGet("download-url")]
+    public IActionResult GetDownloadUrl([FromQuery] string key, [FromQuery] string? prompt = null)
+    {
+        key = Uri.UnescapeDataString(key);
+        var fileName = BuildFileNameFromPrompt(prompt, Path.GetFileName(key));
+        var url = _storage.GetPresignedDownloadUrl(key, fileName, "image/png");
+        return Ok(new { url });
+    }
+
+    private static string BuildFileNameFromPrompt(string? prompt, string fallbackBaseName)
+    {
+        if (string.IsNullOrWhiteSpace(prompt))
+            return EnsurePng(fallbackBaseName);
+
+        var words = Regex.Matches(prompt.ToLowerInvariant(), "[a-z0-9]+")
+                         .Select(m => m.Value)
+                         .Take(6);
+        var slug = string.Join("-", words).Trim('-');
+        if (string.IsNullOrEmpty(slug)) slug = "imagem";
+        return $"{slug}.png";
+    }
+
+    private static string EnsurePng(string name)
+    {
+        var baseName = Path.GetFileNameWithoutExtension(name);
+        return $"{(string.IsNullOrWhiteSpace(baseName) ? "imagem" : baseName)}.png";
+    }
+}

--- a/Services/Storage/IStorageService.cs
+++ b/Services/Storage/IStorageService.cs
@@ -3,5 +3,6 @@ namespace Imagino.Api.Services.Storage
     public interface IStorageService
     {
         Task<string> UploadAsync(Stream stream, string key, string contentType);
+        string GetPresignedDownloadUrl(string key, string fileName, string contentType = "image/png");
     }
 }

--- a/Services/Storage/R2StorageService.cs
+++ b/Services/Storage/R2StorageService.cs
@@ -1,3 +1,4 @@
+using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.Extensions.Options;
@@ -42,6 +43,23 @@ namespace Imagino.Api.Services.Storage
 
             await _client.PutObjectAsync(request);
             return $"{_settings.PublicUrl}/{key}";
+        }
+
+        public string GetPresignedDownloadUrl(string key, string fileName, string contentType = "image/png")
+        {
+            typeof(AWSConfigsS3).GetProperty("UseSignatureVersion4")?.SetValue(null, true);
+            var req = new GetPreSignedUrlRequest
+            {
+                BucketName = _settings.BucketName,
+                Key = key,
+                Expires = DateTime.UtcNow.AddMinutes(5),
+                ResponseHeaderOverrides = new ResponseHeaderOverrides
+                {
+                    ContentDisposition = $"attachment; filename=\"{fileName}\"",
+                    ContentType = contentType
+                }
+            };
+            return _client.GetPreSignedURL(req);
         }
     }
 }


### PR DESCRIPTION
## Summary
- generate presigned GET URLs from R2 storage
- add files controller to expose download-url endpoint with prompt-based filenames

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a525169e68832f84073b04e66730d9