### PR TITLE
Ensure project file copied explicitly in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 # copy csproj and restore as distinct layers
-COPY Imagino.Api.csproj ./
+COPY ["Imagino.Api.csproj", "./"]
 RUN dotnet restore
 
 # copy everything else and build


### PR DESCRIPTION
## Summary
- copy Imagino.Api.csproj explicitly in Dockerfile for clearer layering

## Testing
- `dotnet test`
- `docker build -t imagino-api-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a7553d8ac8832fb31fb5c38360a68e