### PR TITLE
Add frontend URL configuration and use in Google login redirect

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -2,10 +2,12 @@
 using Imagino.Api.Repository;
 using Imagino.Api.Services;
 using Imagino.Api.DTOs;
+using Imagino.Api.Settings;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
 using System;
 using System.Threading.Tasks;
 
@@ -21,8 +23,9 @@ namespace Imagino.Api.Controllers
         private readonly IConfiguration _config;
         private readonly IRefreshTokenRepository _refreshTokens;
         private readonly IWebHostEnvironment _env;
+        private readonly FrontendSettings _frontendSettings;
 
-        public AuthController(IUserRepository users, IUserService userService, IJwtService jwt, IConfiguration config, IRefreshTokenRepository refreshTokens, IWebHostEnvironment env)
+        public AuthController(IUserRepository users, IUserService userService, IJwtService jwt, IConfiguration config, IRefreshTokenRepository refreshTokens, IWebHostEnvironment env, IOptions<FrontendSettings> frontendSettings)
         {
             _users = users;
             _userService = userService;
@@ -30,6 +33,7 @@ namespace Imagino.Api.Controllers
             _config = config;
             _refreshTokens = refreshTokens;
             _env = env;
+            _frontendSettings = frontendSettings.Value;
         }
 
         public record RegisterRequest(string Email, string Password, string? Username, string? PhoneNumber, SubscriptionType Subscription, int Credits);
@@ -185,7 +189,7 @@ namespace Imagino.Api.Controllers
 
             var token = _jwt.GenerateToken(user.Id, user.Email);
 
-            var redirectUrl = $"http://localhost:3000/google-auth?token={token}&username={user.Username}";
+            var redirectUrl = $"{_frontendSettings.BaseUrl}/google-auth?token={token}&username={user.Username}";
             return Redirect(redirectUrl);
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -22,6 +22,8 @@ builder.Configuration.GetSection("ImageGeneratorSettings"));
 
 builder.Services.Configure<ReplicateSettings>(
 builder.Configuration.GetSection("ReplicateSettings"));
+builder.Services.Configure<FrontendSettings>(
+builder.Configuration.GetSection("Frontend"));
 builder.Services.AddSingleton<ImageJobRepository>();
 
 builder.Services.AddSingleton<IMongoClient>(sp =>

--- a/Settings/FrontendSettings.cs
+++ b/Settings/FrontendSettings.cs
@@ -1,0 +1,8 @@
+namespace Imagino.Api.Settings
+{
+    public class FrontendSettings
+    {
+        public string BaseUrl { get; set; } = string.Empty;
+    }
+}
+

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -36,5 +36,8 @@
     "PublicUrl": "https://pub-b729fc455c624ae898327540a3d00dd3.r2.dev",
     "AccessKeyId": "",
     "SecretAccessKey": ""
+  },
+  "Frontend": {
+    "BaseUrl": "https://imagino-front.vercel.app"
   }
 }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -11,13 +11,13 @@
     "MongoConnection": "mongodb+srv://danielzanelato1:Zanelato2025%21@imagino-cluster.oref9np.mongodb.net/",
     "MongoDatabase": "imagino",
     "JobsCollection": "image_jobs",
-    "WebhookUrl": "https://d5bc5ce0bef3.ngrok-free.app/api/webhooks/runpod",
+    "WebhookUrl": "https://63c63823bc07.ngrok-free.app/api/webhooks/runpod",
     "ImageCost": 5
   },
   "ReplicateSettings": {
     "ApiKey": "",
     "ModelUrl": "https://api.replicate.com/v1/models/black-forest-labs/flux-1.1-pro/predictions",
-    "WebhookUrl": "https://d5bc5ce0bef3.ngrok-free.app/api/webhooks/replicate"
+    "WebhookUrl": "https://63c63823bc07.ngrok-free.app/api/webhooks/replicate"
   },
   "Jwt": {
     "Secret": "",
@@ -38,6 +38,6 @@
     "SecretAccessKey": ""
   },
   "Frontend": {
-    "BaseUrl": "https://imagino-front.vercel.app"
+    "BaseUrl": "http://localhost:3000"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -14,13 +14,15 @@
     "JobsCollection": "image_jobs",
     "ImageCost": 5
   },
-  "AllowedHosts": "*"
-  ,
+  "AllowedHosts": "*",
   "R2Settings": {
     "ServiceUrl": "https://f3915d7185410d3a7d3a9599e22194af.r2.cloudflarestorage.com",
     "BucketName": "imagino-images",
     "PublicUrl": "https://pub-b729fc455c624ae898327540a3d00dd3.r2.dev",
     "AccessKeyId": "",
     "SecretAccessKey": ""
+  },
+  "Frontend": {
+    "BaseUrl": "https://imagino-front.vercel.app"
   }
 }


### PR DESCRIPTION
## Summary
- add `FrontendSettings` to centralize frontend base URL
- wire settings into DI and use in Google login callback redirect
- expose default frontend URL in configuration files

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d5ceaba8832fbfe54dc585cd1b03