### PR TITLE
refactor: restrict CORS to configured frontend

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -34,15 +34,14 @@ builder.Services.AddSingleton<IMongoClient>(sp =>
 
 // Configuração de CORS
 var corsPolicyName = "AllowFrontend";
-var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+var frontendUrl = builder.Configuration["Frontend:BaseUrl"] ?? string.Empty;
 
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(corsPolicyName, policy =>
     {
         policy
-            .WithOrigins(allowedOrigins)
-            .SetIsOriginAllowedToAllowWildcardSubdomains()
+            .WithOrigins(frontendUrl)
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials();


### PR DESCRIPTION
## Summary
- restrict CORS policy to frontend URL from configuration

## Testing
- `dotnet test`
- `curl -i -H "Origin: https://imagino-front.vercel.app" http://localhost:5000/`


------
https://chatgpt.com/codex/tasks/task_e_68a8e07b8f60832f8755f17b6c196beb