### PR TITLE
Add health check endpoint

### DIFF
--- a/Controllers/HealthController.cs
+++ b/Controllers/HealthController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Imagino.Api.Controllers;
+
+[ApiController]
+[Route("health")]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok(new { status = "ok" });
+}

--- a/Imagino.Api.Tests/HealthCheckTests.cs
+++ b/Imagino.Api.Tests/HealthCheckTests.cs
@@ -1,0 +1,21 @@
+using Imagino.Api.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Imagino.Api.Tests;
+
+public class HealthCheckTests
+{
+    [Fact]
+    public void Get_ReturnsOkStatus()
+    {
+        var controller = new HealthController();
+
+        var result = controller.Get();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var statusProperty = ok.Value?.GetType().GetProperty("status");
+        var value = statusProperty?.GetValue(ok.Value) as string;
+        Assert.Equal("ok", value);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -185,3 +185,5 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- add controller for `/health` responses
- test health controller returns OK

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68be54e50e00832fbaf06e29fbe467e9