### PR TITLE
Add Stripe credit accrual on payment events

### DIFF
--- a/Controllers/StripeWebhookController.cs
+++ b/Controllers/StripeWebhookController.cs
@@ -161,7 +161,7 @@ namespace Imagino.Api.Controllers
         {
             if (stripeEvent.Data.Object is Invoice invoice)
             {
-                if (!invoice.Paid)
+                if (!string.Equals(invoice.Status, "paid", StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }
@@ -173,12 +173,13 @@ namespace Imagino.Api.Controllers
                 }
 
                 var customerId = invoice.CustomerId;
-                var subscriptionId = invoice.SubscriptionId;
 
                 if (string.IsNullOrEmpty(customerId)) return;
 
                 var user = await _users.GetByStripeCustomerIdAsync(customerId);
                 if (user == null) return;
+
+                var subscriptionId = invoice.RawJObject?["subscription"]?.Value<string>() ?? user.StripeSubscriptionId;
 
                 Stripe.Subscription? subscription = null;
                 if (!string.IsNullOrEmpty(subscriptionId))

--- a/Controllers/StripeWebhookController.cs
+++ b/Controllers/StripeWebhookController.cs
@@ -60,6 +60,10 @@ namespace Imagino.Api.Controllers
                     case "checkout.session.completed":
                         await HandleCheckoutSessionCompleted(stripeEvent);
                         break;
+                    case "invoice.paid":
+                    case "invoice.payment_succeeded":
+                        await HandleInvoicePaid(stripeEvent);
+                        break;
                     case "customer.subscription.updated":
                     case "customer.subscription.deleted":
                         await HandleSubscriptionUpdated(stripeEvent);
@@ -107,9 +111,25 @@ namespace Imagino.Api.Controllers
                     var periodEndUnix = sub.RawJObject?["current_period_end"]?.Value<long?>();
                     if (periodEndUnix.HasValue)
                         user.CurrentPeriodEnd = DateTimeOffset.FromUnixTimeSeconds(periodEndUnix.Value);
+
+                    var priceId = sub.Items.Data.Count > 0 ? sub.Items.Data[0].Price.Id : null;
+                    if (!string.IsNullOrEmpty(priceId))
+                    {
+                        user.Plan = MapPlanFromPrice(priceId, user.Plan);
+                    }
                 }
 
                 await _users.UpdateAsync(user);
+
+                var creditsToAdd = GetCreditsForPlan(user.Plan);
+                if (creditsToAdd > 0 && string.Equals(session.PaymentStatus, "paid", StringComparison.OrdinalIgnoreCase))
+                {
+                    var incremented = await _users.IncrementCreditsAsync(user.Id!, creditsToAdd);
+                    if (incremented)
+                    {
+                        _logger.LogInformation("Credits added on checkout session completed. UserId={UserId}, Plan={Plan}, Credits={Credits}, EventId={EventId}", user.Id, user.Plan, creditsToAdd, stripeEvent.Id);
+                    }
+                }
             }
         }
 
@@ -135,6 +155,86 @@ namespace Imagino.Api.Controllers
 
                 await _users.UpdateAsync(user);
             }
+        }
+
+        private async Task HandleInvoicePaid(Event stripeEvent)
+        {
+            if (stripeEvent.Data.Object is Invoice invoice)
+            {
+                if (!invoice.Paid)
+                {
+                    return;
+                }
+
+                if (string.Equals(invoice.BillingReason, "subscription_create", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Crédito inicial já tratado no checkout
+                    return;
+                }
+
+                var customerId = invoice.CustomerId;
+                var subscriptionId = invoice.SubscriptionId;
+
+                if (string.IsNullOrEmpty(customerId)) return;
+
+                var user = await _users.GetByStripeCustomerIdAsync(customerId);
+                if (user == null) return;
+
+                Stripe.Subscription? subscription = null;
+                if (!string.IsNullOrEmpty(subscriptionId))
+                {
+                    var subscriptionService = new SubscriptionService();
+                    subscription = await subscriptionService.GetAsync(subscriptionId);
+
+                    user.StripeSubscriptionId = subscription.Id;
+                    user.SubscriptionStatus = subscription.Status;
+
+                    var periodEnd = subscription.RawJObject?["current_period_end"]?.Value<long?>();
+                    if (periodEnd.HasValue)
+                        user.CurrentPeriodEnd = DateTimeOffset.FromUnixTimeSeconds(periodEnd.Value);
+
+                    var priceId = subscription.Items.Data.Count > 0 ? subscription.Items.Data[0].Price.Id : null;
+                    if (!string.IsNullOrEmpty(priceId))
+                    {
+                        user.Plan = MapPlanFromPrice(priceId, user.Plan);
+                    }
+
+                    await _users.UpdateAsync(user);
+                }
+
+                var creditsToAdd = GetCreditsForPlan(user.Plan);
+                if (creditsToAdd > 0)
+                {
+                    var creditEventId = $"invoice-credit-{invoice.Id}";
+                    if (await _events.ExistsAsync(creditEventId)) return;
+
+                    var incremented = await _users.IncrementCreditsAsync(user.Id!, creditsToAdd);
+                    if (incremented)
+                    {
+                        await _events.CreateAsync(new Models.StripeEventRecord { EventId = creditEventId, Created = DateTime.UtcNow });
+                        _logger.LogInformation("Credits added on invoice paid. UserId={UserId}, Plan={Plan}, Credits={Credits}, EventId={EventId}, InvoiceId={InvoiceId}", user.Id, user.Plan, creditsToAdd, stripeEvent.Id, invoice.Id);
+                    }
+                }
+            }
+        }
+
+        private int GetCreditsForPlan(string? plan)
+        {
+            if (string.IsNullOrEmpty(plan)) return 0;
+
+            return plan.ToUpperInvariant() switch
+            {
+                "PRO" => _settings.CreditsPro,
+                "ULTRA" => _settings.CreditsUltra,
+                _ => 0
+            };
+        }
+
+        private string MapPlanFromPrice(string priceId, string? currentPlan)
+        {
+            if (priceId == _settings.PricePro) return "PRO";
+            if (priceId == _settings.PriceUltra) return "ULTRA";
+            return currentPlan ?? string.Empty;
         }
     }
 }

--- a/Settings/StripeSettings.cs
+++ b/Settings/StripeSettings.cs
@@ -9,5 +9,7 @@ namespace Imagino.Api.Settings
         public string SuccessUrl { get; set; } = default!;
         public string CancelUrl { get; set; } = default!;
         public string PortalReturnUrl { get; set; } = default!;
+        public int CreditsPro { get; set; } = 100;
+        public int CreditsUltra { get; set; } = 300;
     }
 }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -65,15 +65,17 @@
     "HttpOnly": true,
     "ExpiresDays": 7
   },
-  "Stripe": {
-    "ApiKey": "",
-    "WebhookSecret": "",
-    "PricePro": "",
-    "PriceUltra": "",
-    "SuccessUrl": "https://imagino-front.vercel.app/checkout/success",
-    "CancelUrl": "https://imagino-front.vercel.app/checkout/cancel",
-    "PortalReturnUrl": "https://imagino-front.vercel.app/account"
-  },
+    "Stripe": {
+      "ApiKey": "",
+      "WebhookSecret": "",
+      "PricePro": "",
+      "PriceUltra": "",
+      "SuccessUrl": "https://imagino-front.vercel.app/checkout/success",
+      "CancelUrl": "https://imagino-front.vercel.app/checkout/cancel",
+      "PortalReturnUrl": "https://imagino-front.vercel.app/account",
+      "CreditsPro": 100,
+      "CreditsUltra": 300
+    },
   "Resend": {
     "ApiKey": ""
   },

--- a/appsettings.json
+++ b/appsettings.json
@@ -55,5 +55,9 @@
   },
   "VeoSettings": {
     "ApiKey": ""
+  },
+  "Stripe": {
+    "CreditsPro": 100,
+    "CreditsUltra": 300
   }
 }


### PR DESCRIPTION
## Summary
- add configurable credit amounts for PRO and ULTRA Stripe plans
- credit users on checkout completion and paid invoices while updating subscription details
- store invoice-level credit records to avoid duplicate credits across webhook retries

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c2309014832f8aa888a4864ced59)